### PR TITLE
__before_bundle directory should be inside the engine folder. 

### DIFF
--- a/modules/dts-bundler/src/index.ts
+++ b/modules/dts-bundler/src/index.ts
@@ -48,7 +48,7 @@ export async function build (options: Options): Promise<boolean> {
 
     const tsConfigPath = statsQuery.tsConfigPath;
 
-    const unbundledOutDir = ps.join(outDir, '__before_bundle');
+    const unbundledOutDir = ps.join(engine, '__dts_before_bundle');
     const parsedCommandLine = ts.getParsedCommandLineOfConfigFile(
         tsConfigPath, {
             declaration: true,

--- a/modules/utils/src/path.ts
+++ b/modules/utils/src/path.ts
@@ -11,6 +11,10 @@ export function dirname (path: string): string {
     return formatPath(ps.dirname(path));
 }
 
+export function basename (path: string): string {
+    return formatPath(ps.basename(path));
+}
+
 export function join (...args: string[]): string {
     return formatPath(ps.join(...args));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cocos/ccbuild",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cocos/ccbuild",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocos/ccbuild",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "The next generation of build tool for Cocos engine.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Otherwise, dragonbones library will not be found, the bundled .d.ts file will not contain dragonbones librarys, there will be lots of 'codec' type.